### PR TITLE
Comma after last array

### DIFF
--- a/block_myprogress.php
+++ b/block_myprogress.php
@@ -56,7 +56,7 @@ class block_myprogress extends block_base {
             'course-view' => true,
             'site' => false,
             'mod' => false,
-            'my' => false
+            'my' => false,
         );
     }
 

--- a/db/access.php
+++ b/db/access.php
@@ -32,7 +32,7 @@ $capabilities = [
         'contextlevel' => CONTEXT_BLOCK,
         'archetypes' => [
             'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW
+            'manager' => CAP_ALLOW,
         ],
         'clonepermissionsfrom' => 'moodle/site:manageblocks'
     ],

--- a/db/access.php
+++ b/db/access.php
@@ -34,6 +34,6 @@ $capabilities = [
             'editingteacher' => CAP_ALLOW,
             'manager' => CAP_ALLOW,
         ],
-        'clonepermissionsfrom' => 'moodle/site:manageblocks'
+        'clonepermissionsfrom' => 'moodle/site:manageblocks',
     ],
 ];

--- a/db/events.php
+++ b/db/events.php
@@ -29,6 +29,6 @@ $observers = [
     [
         'eventname' => '\core\event\course_module_completion_updated',
         'callback' => '\block_myprogress\observers\modulecompleted::observer',
-        'internal' => false
+        'internal' => false,
     ],
 ];

--- a/version.php
+++ b/version.php
@@ -28,6 +28,5 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->requires = 2011120511;
 $plugin->version = 2023022400;
 $plugin->release = '1.0.0';
-$plugin->supported = [401, 402, 403];
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'block_myprogress';

--- a/version.php
+++ b/version.php
@@ -28,5 +28,6 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->requires = 2011120511;
 $plugin->version = 2023022400;
 $plugin->release = '1.0.0';
+$plugin->supported = [401, 402, 403];
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'block_myprogress';


### PR DESCRIPTION
Hi @willianmano 

My emails seem to be blocked, so I have updated files following code-checker and phpdocs reports

I have tested on a personnal moodle each update and it's ok !

I have just a last warning 
```
[blocks/myprogress/block_myprogress.php]
#55: ········return·array(
Short array syntax must be used to define arrays
```

I tryed to add supported versions after my QATest integrity folowing steps in https://github.com/willianmano/moodle-block_myprogress/issues/7#issue-1941646387, https://github.com/willianmano/moodle-block_myprogress/issues/8#issue-1941650277 and https://github.com/willianmano/moodle-block_myprogress/issues/9#issue-1941654506
But it's not OK...
If you can add it for me, I'll be great...

Hope my commits are correct.

This  plugin can be submitted for integration in the official Moodle plugin database!

Cheers.