### PR TITLE
Update table name too long

### DIFF
--- a/block_myprogress.php
+++ b/block_myprogress.php
@@ -123,6 +123,6 @@ class block_myprogress extends block_base {
     public function instance_delete() {
         global $DB;
 
-        return $DB->delete_records('block_myprogress_course_progress', ['courseid' => $this->page->course->id]);
+        return $DB->delete_records('block_myprogress_course', ['courseid' => $this->page->course->id]);
     }
 }

--- a/classes/util/coursecompletion.php
+++ b/classes/util/coursecompletion.php
@@ -62,13 +62,13 @@ class coursecompletion {
     public function insert_or_update_user_course_progress($userid, $progress) {
         global $DB;
 
-        $courseprogress = $DB->get_record('block_myprogress_course_progress', ['courseid' => $this->course->id, 'userid' => $userid]);
+        $courseprogress = $DB->get_record('block_myprogress_course', ['courseid' => $this->course->id, 'userid' => $userid]);
 
         if ($courseprogress) {
             $courseprogress->progress = $progress;
             $courseprogress->timemodified = time();
 
-            return $DB->update_record('block_myprogress_course_progress', $courseprogress);
+            return $DB->update_record('block_myprogress_course', $courseprogress);
         }
 
         $courseprogress = new \stdClass();
@@ -78,7 +78,7 @@ class coursecompletion {
         $courseprogress->timecreated = time();
         $courseprogress->timemodified = time();
 
-        return $DB->insert_record('block_myprogress_course_progress', $courseprogress);
+        return $DB->insert_record('block_myprogress_course', $courseprogress);
     }
 
     /**

--- a/classes/util/progress.php
+++ b/classes/util/progress.php
@@ -42,7 +42,7 @@ class progress {
             $userid = $USER->id;
         }
 
-        $record = $DB->get_record('block_myprogress_course_progress', ['courseid' => $courseid, 'userid' => $userid]);
+        $record = $DB->get_record('block_myprogress_course', ['courseid' => $courseid, 'userid' => $userid]);
 
         if (!$record) {
             return 0;
@@ -64,7 +64,7 @@ class progress {
         global $DB;
 
         $sql = 'SELECT AVG(progress) as average
-                FROM {block_myprogress_course_progress}
+                FROM {block_myprogress_course}
                 WHERE courseid = :courseid';
 
         $record = $DB->get_record_sql($sql, ['courseid' => $courseid]);
@@ -104,7 +104,7 @@ class progress {
             $sql = 'SELECT g.id, g.name, AVG(cp.progress) as average
                     FROM {groups} g
                     INNER JOIN {groups_members} gm ON gm.groupid = g.id
-                    LEFT JOIN {block_myprogress_course_progress} cp ON cp.userid = gm.userid AND cp.courseid = :courseid
+                    LEFT JOIN {block_myprogress_course} cp ON cp.userid = gm.userid AND cp.courseid = :courseid
                     WHERE g.id = :groupid';
 
             $record = $DB->get_record_sql($sql, ['courseid' => $courseid, 'groupid' => $usergroup]);
@@ -161,7 +161,7 @@ class progress {
             $sql = 'SELECT c.id, c.name, AVG(cp.progress) as average
                     FROM {cohort} c
                     INNER JOIN {cohort_members} cm ON c.id = cm.cohortid
-                    LEFT JOIN {block_myprogress_course_progress} cp ON cp.userid = cm.userid AND cp.courseid = :courseid
+                    LEFT JOIN {block_myprogress_course} cp ON cp.userid = cm.userid AND cp.courseid = :courseid
                     WHERE c.id = :cohortid';
 
             $record = $DB->get_record_sql($sql, ['cohortid' => $usercohort->id, 'courseid' => $courseid]);

--- a/db/install.xml
+++ b/db/install.xml
@@ -4,7 +4,7 @@
        xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
   <TABLES>
-    <TABLE NAME="block_myprogress_course_progress" COMMENT="Stores the progress of a user on a course.">
+    <TABLE NAME="block_myprogress_course" COMMENT="Stores the progress of a user on a course.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Course id."/>

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->requires = 2011120511;
-$plugin->version = 2023103100;
-$plugin->release = '1.0.1';
+$plugin->version = 2023110900;
+$plugin->release = '1.0.2';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'block_myprogress';


### PR DESCRIPTION
Hi @willianmano 

This PR will fix the https://github.com/willianmano/moodle-block_myprogress/issues/16 issue because of a too long db name for Moodle 4.1 and 4.2...

Cheers.